### PR TITLE
feat: enable data source info in new left navigation

### DIFF
--- a/public/apps/configuration/app-router.tsx
+++ b/public/apps/configuration/app-router.tsx
@@ -41,7 +41,7 @@ import { Action, RouteItem, SubAction } from './types';
 import { ResourceType } from '../../../common';
 import { buildHashUrl, buildUrl } from './utils/url-builder';
 import { CrossPageToast } from './cross-page-toast';
-import { getDataSourceFromUrl } from '../../utils/datasource-utils';
+import { getDataSourceFromUrl, LocalCluster } from '../../utils/datasource-utils';
 
 const LANDING_PAGE_URL = '/getstarted';
 
@@ -150,8 +150,6 @@ export interface DataSourceContextType {
   dataSource: DataSourceOption;
   setDataSource: React.Dispatch<React.SetStateAction<DataSourceOption>>;
 }
-
-export const LocalCluster = { label: 'Local cluster', id: '' };
 
 export const DataSourceContext = createContext<DataSourceContextType | null>(null);
 

--- a/public/apps/configuration/top-nav-menu.tsx
+++ b/public/apps/configuration/top-nav-menu.tsx
@@ -17,7 +17,7 @@ import React from 'react';
 import { DataSourceSelectableConfig } from 'src/plugins/data_source_management/public';
 import { DataSourceOption } from 'src/plugins/data_source_management/public/components/data_source_menu/types';
 import { AppDependencies } from '../types';
-import { setDataSourceInUrl } from '../../utils/datasource-utils';
+import { setDataSourceInUrl, setDataSource as setDataSourceInSubscription } from '../../utils/datasource-utils';
 
 export interface TopNavMenuProps extends AppDependencies {
   dataSourcePickerReadOnly: boolean;
@@ -44,6 +44,7 @@ export const SecurityPluginTopNavMenu = React.memo(
     const wrapSetDataSourceWithUpdateUrl = (dataSources: DataSourceOption[]) => {
       setDataSourceInUrl(dataSources[0]);
       setDataSource(dataSources[0]);
+      setDataSourceInSubscription(dataSources[0]);
     };
 
     return dataSourceEnabled ? (

--- a/public/apps/configuration/top-nav-menu.tsx
+++ b/public/apps/configuration/top-nav-menu.tsx
@@ -17,7 +17,10 @@ import React from 'react';
 import { DataSourceSelectableConfig } from 'src/plugins/data_source_management/public';
 import { DataSourceOption } from 'src/plugins/data_source_management/public/components/data_source_menu/types';
 import { AppDependencies } from '../types';
-import { setDataSourceInUrl, setDataSource as setDataSourceInSubscription } from '../../utils/datasource-utils';
+import {
+  setDataSourceInUrl,
+  setDataSource as setDataSourceInSubscription,
+} from '../../utils/datasource-utils';
 
 export interface TopNavMenuProps extends AppDependencies {
   dataSourcePickerReadOnly: boolean;

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -53,7 +53,11 @@ import { addTenantToShareURL } from './services/shared-link';
 import { interceptError } from './utils/logout-utils';
 import { tenantColumn, getNamespacesToRegister } from './apps/configuration/utils/tenant-utils';
 import { getDashboardsInfoSafe } from './utils/dashboards-info-utils';
-import { dataSource$, getDataSourceEnabledUrl, getDataSourceFromUrl, setDataSourceInUrl } from './utils/datasource-utils';
+import {
+  dataSource$,
+  getDataSourceEnabledUrl,
+  getDataSourceFromUrl,
+} from './utils/datasource-utils';
 
 async function hasApiPermission(core: CoreSetup): Promise<boolean | undefined> {
   try {
@@ -94,9 +98,9 @@ export class SecurityPlugin
   private updateDefaultRouteOfSecurityApplications: AppUpdater = () => {
     const url = getDataSourceEnabledUrl(getDataSourceFromUrl());
     return {
-      defaultPath: `?${url.searchParams.toString()}`
+      defaultPath: `?${url.searchParams.toString()}`,
     };
-  }
+  };
 
   private appStateUpdater = new BehaviorSubject(this.updateDefaultRouteOfSecurityApplications);
 

--- a/public/utils/datasource-utils.ts
+++ b/public/utils/datasource-utils.ts
@@ -48,7 +48,9 @@ export function setDataSourceInUrl(dataSource: DataSourceOption) {
 
 export const LocalCluster = { label: 'Local cluster', id: '' };
 
-export const dataSource$ = new BehaviorSubject<DataSourceOption>(getDataSourceFromUrl() || LocalCluster);
+export const dataSource$ = new BehaviorSubject<DataSourceOption>(
+  getDataSourceFromUrl() || LocalCluster
+);
 
 export function setDataSource(dataSource: DataSourceOption) {
   dataSource$.next(dataSource);

--- a/public/utils/datasource-utils.ts
+++ b/public/utils/datasource-utils.ts
@@ -13,6 +13,7 @@
  *   permissions and limitations under the License.
  */
 
+import { BehaviorSubject } from 'rxjs';
 import { DataSourceOption } from 'src/plugins/data_source_management/public/components/data_source_menu/types';
 
 const DATASOURCEURLKEY = 'dataSource';
@@ -35,8 +36,20 @@ export function getDataSourceFromUrl(): DataSourceOption {
   }
 }
 
-export function setDataSourceInUrl(dataSource: DataSourceOption) {
+export function getDataSourceEnabledUrl(dataSource: DataSourceOption) {
   const url = new URL(window.location.href);
   url.searchParams.set(DATASOURCEURLKEY, JSON.stringify(dataSource));
-  window.history.replaceState({}, '', url.toString());
+  return url;
+}
+
+export function setDataSourceInUrl(dataSource: DataSourceOption) {
+  window.history.replaceState({}, '', getDataSourceEnabledUrl(dataSource).toString());
+}
+
+export const LocalCluster = { label: 'Local cluster', id: '' };
+
+export const dataSource$ = new BehaviorSubject<DataSourceOption>(getDataSourceFromUrl() || LocalCluster);
+
+export function setDataSource(dataSource: DataSourceOption) {
+  dataSource$.next(dataSource);
 }


### PR DESCRIPTION
### Description

Fix the issue that data source info is erased when navigating features in new left navigation.

### Category

Bug fix

### Why these changes are required?

[#7171](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7171)

### What is the old behavior before changes and new behavior after changes?

Old behavior can be found in [#7171](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7171)

#### For the new behavior:
https://github.com/derek-ho/security-dashboards-plugin/assets/13493605/09f12353-aef0-4aba-8061-cb9de12feb47


### Issues Resolved
[#7171](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7171)

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).